### PR TITLE
Allow display of float scores in /event/:id

### DIFF
--- a/app/initializer/scripts/numeral-initializer.js
+++ b/app/initializer/scripts/numeral-initializer.js
@@ -5,6 +5,6 @@ import 'numeral/locales/fr';
 export default () => {
     console.info('|--- NUMERAL');
     // Initialise numeral conf 
-    init();
+    init('0,0.[00]');
     console.info('   |--- Numeral correctly initialized.');
 }


### PR DESCRIPTION
Allow display of float scores in event detail page while keeping integers without decimals after https://github.com/FightForSub/FFS-Api/issues/14 update.